### PR TITLE
#211: strengthen say substitution test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ desc 'Run all unit tests'
 Rake::TestTask.new(:test) do |test|
   require 'minitest/reporters'
   Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
-Minitest.load :minitest_reporter
+  Minitest.load_plugins
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.warning = true

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -15,4 +15,4 @@ require 'minitest/autorun'
 
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
-Minitest.load :minitest_reporter
+Minitest.load_plugins

--- a/test/test_say.rb
+++ b/test/test_say.rb
@@ -13,6 +13,9 @@ require_relative '../lib/say'
 # License:: MIT
 class TestSay < Minitest::Test
   def test_simple_scenario
-    assert(say('Hello, {name}!').start_with?('Hello'))
+    out = say('Hello, {name}!')
+
+    refute_includes(out, '{name}')
+    assert_match(/\AHello, (Jeff|Nicole|Peter|Sarah|John|Natasha)!\z/, out)
   end
 end


### PR DESCRIPTION
Fixes #211

Summary:
- Strengthens `test/test_say.rb` so it verifies `{name}` is removed and the output matches one of the allowed names.
- Replaces the existing invalid `Minitest.load` calls with `Minitest.load_plugins` so the repo test harness runs under the Ruby 3.4 workflow.

Validation:
- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec ruby -Itest test/test_say.rb'` -> 1 test, 4 assertions, 0 failures, 0 errors, 0 skips.\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rake test'` -> 1 test, 4 assertions, 0 failures, 0 errors, 0 skips.\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rubocop Rakefile test/test__helper.rb test/test_say.rb'` -> 3 files inspected, no offenses detected.\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rake'` -> unit test passed, 1 judge/1 fixture passed, 6 files inspected by RuboCop with no offenses.\n- `git diff --check` -> passed.\n- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.\n\nNo secrets or generated coverage artifacts are included.