### PR TITLE
#213: fix README bundler command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ your pull request. You will need to have
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash
-bundle up
+bundle install
 bundle exec rake
 ```
 


### PR DESCRIPTION
Fixes #213.

## Summary
- Replace the README quick-start `bundle up` line with `bundle install` for a fresh checkout.
- Leave the following `bundle exec rake` instruction unchanged.

## Validation
- `npx --yes markdownlint-cli2 README.md` -> 0 errors.
- `git diff --check`
- `gitleaks protect --staged --no-banner --redact --verbose`

## Note
- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle-213:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle install >/dev/null && bundle exec rake'` currently stops before tests on the existing `Minitest.load` Ruby 3.4 harness issue. That baseline issue is already covered by open PR #214, so this branch stays scoped to the README typo.
