### PR TITLE
#212: pass job id to judges

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ desc 'Run all unit tests'
 Rake::TestTask.new(:test) do |test|
   require 'minitest/reporters'
   Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
-Minitest.load :minitest_reporter
+  Minitest.load_plugins
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.warning = true

--- a/entry.sh
+++ b/entry.sh
@@ -19,4 +19,5 @@ fi
 
 self=$(dirname "$0")
 
-judges --verbose update --quiet --summary --max-cycles=3 --no-log --lib "${self}/lib" "${self}/judges" "${home}/base.fb"
+judges --verbose update --quiet --summary --max-cycles=3 --no-log \
+       --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -15,4 +15,4 @@ require 'minitest/autorun'
 
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
-Minitest.load :minitest_reporter
+Minitest.load_plugins

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+require_relative 'test__helper'
+
+# Test for "entry.sh".
+class TestEntry < Minitest::Test
+  JUDGES_STUB = <<~'RUBY'
+    #!/usr/bin/env ruby
+    File.write(ENV.fetch('JUDGES_ARGS_FILE'), ARGV.join("\n"))
+  RUBY
+
+  def test_forwards_job_id_to_judges_options
+    Dir.mktmpdir do |dir|
+      home = File.join(dir, 'home')
+      FileUtils.mkdir_p(home)
+      args = File.join(dir, 'args.txt')
+      passed = run_entry(judges_stub(dir), home, args)
+
+      assert_includes(passed, 'update')
+      assert_includes(passed, '--option')
+      assert_includes(passed, 'id=job-42')
+      assert_equal("#{home}/base.fb", passed.last)
+    end
+  end
+
+  private
+
+  def judges_stub(dir)
+    bin = File.join(dir, 'bin')
+    FileUtils.mkdir_p(bin)
+    stub = File.join(bin, 'judges')
+    File.write(stub, JUDGES_STUB)
+    FileUtils.chmod(0o755, stub)
+    bin
+  end
+
+  def run_entry(bin, home, args)
+    stdout, stderr, status = Open3.capture3(
+      { 'PATH' => "#{bin}:#{ENV.fetch('PATH')}", 'JUDGES_ARGS_FILE' => args },
+      './entry.sh', 'job-42', home
+    )
+
+    assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+    File.readlines(args, chomp: true)
+  end
+end


### PR DESCRIPTION
/claim #212
Fixes #212

Summary:
- forwards the validated `entry.sh` job id to `judges update` as `--option id=...`, which is the supported way to expose command-line options to judge scripts as `$options.id`
- adds a regression test that stubs `judges` and asserts the entry script passes `update`, `--option`, `id=job-42`, and the selected `base.fb` path
- replaces the obsolete `Minitest.load` call with `Minitest.load_plugins` so the repository test task runs under the configured Ruby 3.4 CI runtime

Validation:
- `shellcheck entry.sh`
- `docker run --rm -v "$PWD":/work -w /work python:3.14 bash -lc 'pip install -q bashate && readarray -t files < <(find . -name "*.sh") && bashate -i E006,E003 "${files[@]}"'`\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec ruby -Itest test/test_entry.rb'` -> 1 test, 8 assertions, 0 failures\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rake test'` -> 2 tests, 9 assertions, 0 failures\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rubocop Rakefile test/test__helper.rb test/test_entry.rb'` -> no offenses\n- `docker run --rm -v "$PWD":/work -v /tmp/swarm-template-bundle:/usr/local/bundle -w /work ruby:3.4 bash -lc 'bundle exec rake'` -> unit tests passed, 1 judge/1 fixture passed, RuboCop 7 files no offenses\n- `git diff --cached --check`\n- `gitleaks protect --staged --no-banner --redact --verbose`\n\nNo secrets, credentials, wallet material, live service calls, or production mutations were used.