### PR TITLE
#211: validate say name substitution

### DIFF
--- a/test/test_say.rb
+++ b/test/test_say.rb
@@ -13,6 +13,8 @@ require_relative '../lib/say'
 # License:: MIT
 class TestSay < Minitest::Test
   def test_simple_scenario
-    assert(say('Hello, {name}!').start_with?('Hello'))
+    out = say('Hello, {name}!')
+    refute_includes(out, '{name}')
+    assert_match(/\AHello, (Jeff|Nicole|Peter|Sarah|John|Natasha)!\z/, out)
   end
 end


### PR DESCRIPTION
Closes #211.

The old assertion only checked that the output started with `Hello`, which was already true for the input before `{name}` substitution. This change validates the behavior that matters: the placeholder is removed and the rendered name is one of the supported names with the full greeting shape intact.

Validation:
- `ruby test/test_say.rb` -> `1 tests, 4 assertions, 0 failures, 0 errors, 0 skips`
- `git diff --cached --check` before commit -> clean
- `gitleaks protect --staged --no-banner --redact --verbose` -> no leaks found

Limitation:
- `bundle exec rake` currently stops before tests on the existing baseline `NoMethodError: private method 'load' called for Minitest:Module` at `Rakefile:19` (`Minitest.load :minitest_reporter`).

Duplicate/currentness checks before opening:
- Issue #211 was still open and unassigned.
- GitHub PR searches for `211 say name substitution test_say` and `test_say start_with Hello substitution` returned no matching PRs.