### PR TITLE
#213: fix README bundler command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ your pull request. You will need to have
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash
-bundle up
+bundle install
 bundle exec rake
 ```
 


### PR DESCRIPTION
Closes #213.

Replaces the invalid `bundle up` README command with `bundle install`, matching the project workflow and Bundler's documented install command for fresh checkouts.

Validation:
- `bundle install --no-color`
- `git diff --check`
- `rg -n 'bundle up|bundle install|bundle update' README.md .github/workflows/rake.yml`\n- `gitleaks detect --no-banner --redact --source .`\n\nLimitation:\n- `bundle exec rake` currently fails before tests on the baseline `Rakefile` line `Minitest.load :minitest_reporter` with `NoMethodError: private method load called for module Minitest`; this docs-only patch does not touch that behavior.