### PR TITLE
#213: fix README Bundler install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ your pull request. You will need to have
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash
-bundle up
+bundle install
 bundle exec rake
 ```
 


### PR DESCRIPTION
Closes #213.

This updates the quick-start command in `README.md` from `bundle up` to `bundle install`, which is the install command a fresh checkout should run before `bundle exec rake`.

Validation:
- `env BUNDLE_PATH=/private/tmp/bundle-swarm-template-213 mise x ruby@3.3.11 -- bundle install`
- `env BUNDLE_PATH=/private/tmp/bundle-swarm-template-213 mise x ruby@3.3.11 -- bundle exec rake` -> 2 tests, 12 assertions, 0 failures; 1 judge test passed; RuboCop no offenses
- `git diff --check origin/master..HEAD`
- `git diff --no-ext-diff origin/master..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found