### PR TITLE
#213: Fix README Bundler command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ your pull request. You will need to have
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash
-bundle up
+bundle install
 bundle exec rake
 ```
 


### PR DESCRIPTION
Closes #213

## Summary
- replace the invalid `bundle up` quick-start command with `bundle install`
- keep the documented `bundle exec rake` validation step unchanged

## Validation
- `env BUNDLE_PATH=/private/tmp/bundle-swarm-template-213 mise x ruby@3.3 -- bundle install`
- `env BUNDLE_PATH=/private/tmp/bundle-swarm-template-213 mise x ruby@3.3 -- bundle exec rake test` -> 2 tests, 12 assertions, 0 failures, 0 errors
- `env BUNDLE_PATH=/private/tmp/bundle-swarm-template-213 mise x ruby@3.3 -- bundle exec rake` -> 2 tests, 12 assertions, 0 failures, 0 errors; 1 judge test passed; RuboCop 7 files, no offenses
- `npx --yes markdownlint-cli2 README.md` -> 0 errors
- `git diff origin/master...HEAD --check`
- `git diff origin/master...HEAD --binary | gitleaks stdin --no-banner --redact --exit-code 1 -` -> no leaks

No secrets included.