### PR TITLE
#230: tighten hello-said.yml to assert the documented name set

### DIFF
--- a/judges/say-hello/hello-said.yml
+++ b/judges/say-hello/hello-said.yml
@@ -10,4 +10,7 @@ input:
     hi: 'How are you?'
 expected:
   - /fb[count(f)=1]
-  - /fb/f[_id=1 and (hello="Hello, Jeff!" or hello="Hello, Nicole!" or hello="Hello, Peter!" or hello="Hello, Sarah!" or hello="Hello, John!" or hello="Hello, Natasha!")]
+  - >-
+    /fb/f[_id=1 and (hello="Hello, Jeff!" or hello="Hello, Nicole!" or
+    hello="Hello, Peter!" or hello="Hello, Sarah!" or hello="Hello, John!" or
+    hello="Hello, Natasha!")]

--- a/judges/say-hello/hello-said.yml
+++ b/judges/say-hello/hello-said.yml
@@ -10,4 +10,4 @@ input:
     hi: 'How are you?'
 expected:
   - /fb[count(f)=1]
-  - /fb/f[_id=1]/hello
+  - /fb/f[_id=1 and (hello="Hello, Jeff!" or hello="Hello, Nicole!" or hello="Hello, Peter!" or hello="Hello, Sarah!" or hello="Hello, John!" or hello="Hello, Natasha!")]


### PR DESCRIPTION
Closes #230

The judge fixture at `judges/say-hello/hello-said.yml` only checked that the `hello` element existed on fact `_id=1`. The fixture passed for any non-empty value, so dropping the `{name}` substitution from `lib/say.rb`, returning an empty string, or changing the greeting shape did not fail the test.

The XPath assertion now pins `hello` to one of the six names the `say()` contract documents (`Jeff`, `Nicole`, `Peter`, `Sarah`, `John`, `Natasha`), wrapped in the `Hello, ...!` shape `say-hello.rb` produces. The original `matches()` suggestion in the issue relies on XPath 2.0, which the Nokogiri-backed `judges test` engine does not provide, so the fix uses an explicit `or` over the six valid greetings.

`bundle exec rake` runs the Minitest suite (`2 tests, 13 assertions, 0 failures`), the judge test (`say-hello/hello-said` OK in 25 ms), and RuboCop (`7 files inspected, no offenses`). All green on the branch tip.
