### PR TITLE
Fix stale copyright holder in REUSE override

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
 version = 1
@@ -28,5 +28,5 @@ path = [
     "renovate.json",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"
+SPDX-FileCopyrightText = "Copyright (c) 2024-2026 Zerocracy"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
/claim #233

## Summary

Update `REUSE.toml` copyright metadata to match the repo-wide Zerocracy SPDX ownership:
- header: `Copyright (c) 2024-2026 Zerocracy`
- `SPDX-FileCopyrightText` override value: `Copyright (c) 2024-2026 Zerocracy`

This keeps REUSE precedence behavior intact and resolves the inconsistency described in issue #233 while leaving the `path` scope unchanged.