### PR TITLE
#237: Fix REUSE copyright holder mismatch

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
 version = 1
@@ -28,5 +28,5 @@ path = [
     "renovate.json",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"
+SPDX-FileCopyrightText = "Copyright (c) 2024-2026 Zerocracy"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
REUSE.toml specified Yegor Bugayenko as the copyright holder, but all source files (.rb, .sh, .yml) use Zerocracy. This mismatch causes the `reuse` CI workflow to flag the repo as non-compliant.

The fix updates both locations in REUSE.toml:
1. The file's own SPDX header
2. The override annotation in `[[annotations]]`

Fixes #237