### PR TITLE
#239: Remove unused RACK_ENV variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,6 @@ require 'rubygems'
 require 'rake'
 require 'rake/clean'
 
-ENV['RACK_ENV'] = 'test'
-
 task default: %i[clean test judges rubocop]
 
 require 'rake/testtask'


### PR DESCRIPTION
Rakefile set `ENV['RACK_ENV'] = 'test'` but the project is not a Rack application. No file reads this variable. Removed the dead line.

Fixes #239