### PR TITLE
#240: Add pull_request trigger to markdown-lint workflow

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,6 +5,11 @@
 name: markdown-lint
 'on':
   push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   markdown-lint:
     timeout-minutes: 15


### PR DESCRIPTION
The markdown-lint workflow only ran on push, with no pull_request trigger. This meant markdown formatting violations in PRs could bypass CI checks entirely.

Added `pull_request` trigger scoped to master branch, consistent with all other workflows.

Fixes #223