### PR TITLE
#242: Add Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+.git
+.bundle
+vendor
+coverage
+doc
+node_modules
+.opencode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+FROM ruby:3.4-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/swarm
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs=4 --retry=3
+
+COPY . .
+
+ENTRYPOINT ["/opt/swarm/entry.sh"]


### PR DESCRIPTION
The project has `entry.sh` designed as a Docker entry point, but no Dockerfile existed to build the container.

Added:
- `Dockerfile` — based on `ruby:3.4-slim`, installs build dependencies, bundles gems, sets entrypoint to entry.sh
- `.dockerignore` — excludes `.git`, `.bundle`, `vendor`, `coverage`, `node_modules`, `.opencode`

Build example:
```
docker build -t swarm-template .
docker run --rm swarm-template job-123 /data
```

Fixes #242