### PR TITLE
#243: Document the meaning of runs: 2 in YAML test

### DIFF
--- a/judges/say-hello/hello-said.yml
+++ b/judges/say-hello/hello-said.yml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
+# Number of cycles to run the judge. First cycle: hi exists, hello absent
+# -> judge creates hello. Second cycle: both exist -> query matches nothing
+# -> no new facts. Final: 1 fact with hello set.
 runs: 2
 input:
   -


### PR DESCRIPTION
The example YAML test `hello-said.yml` used `runs: 2` without explanation. Template users need to understand this pattern to write their own judge tests.

Added comments explaining the two cycles:
- First cycle: `hi` exists, `hello` absent → judge creates hello
- Second cycle: both exist → query matches nothing → idempotency confirmed

Fixes #243