### PR TITLE
#244: Remove duplicate Author/Copyright comments from test_say.rb

### DIFF
--- a/test/test_say.rb
+++ b/test/test_say.rb
@@ -7,10 +7,6 @@ require 'minitest/autorun'
 require_relative 'test__helper'
 require_relative '../lib/say'
 
-# Test for "say.rb".
-# Author:: Yegor Bugayenko (yegor256@gmail.com)
-# Copyright:: Copyright (c) 2024 Yegor Bugayenko
-# License:: MIT
 class TestSay < Minitest::Test
   def test_simple_scenario
     out = say('Hello, {name}!')


### PR DESCRIPTION
test_say.rb had old-style RDoc Author/Copyright/License comments (lines 11-13) that duplicate the SPDX header already present in lines 1-4. Removed the redundant block.

Fixes #258