### PR TITLE
#247: Add .gitattributes for consistent line endings and diff settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+*.rb text
+*.yml text
+*.yaml text
+*.sh text
+*.md text
+*.json text
+Gemfile.lock -diff linguist-generated
+Dockerfile text
+.gitattributes text
+.gitignore text


### PR DESCRIPTION
Added `.gitattributes` with:
- `* text=auto eol=lf` — consistent line endings across platforms
- Type-specific markers for `.rb`, `.yml`, `.sh`, `.md`, `.json`
- `Gemfile.lock -diff linguist-generated` — hides auto-generated lockfile from diffs

Fixes #247