### PR TITLE
#249: Pin actionlint version using reviewdog action

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,10 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+      - uses: reviewdog/action-actionlint@v1.72.0


### PR DESCRIPTION
actionlint was downloaded via `curl | bash` with no version pin, making CI vulnerable to unexpected breaking changes.

Replaced the curl download with `reviewdog/action-actionlint@v1.72.0`:
- Version is pinned and updatable by Renovate
- Cleaner single-step configuration
- Maintained by the reviewdog team

Fixes #249