### PR TITLE
#250: Exclude .opencode/ from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 rdoc/
 target/
 vendor/
+.opencode/


### PR DESCRIPTION
The `.opencode/` directory contains agent working files, AGENTS.md with architecture descriptions, and issue playbooks. It must never be committed.

Added `.opencode/` to `.gitignore` to protect all current and future clones from accidentally committing agent artifacts.

Also added to local `.git/info/exclude` for immediate protection.

Fixes #250