### PR TITLE
#252: Harden entry.sh with input validation and safer defaults

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -27,7 +27,7 @@ if ! command -v judges &>/dev/null; then
   exit 1
 fi
 
-self=$(cd "$(dirname "$0")" && pwd)
+self=$(dirname "$(readlink -f "$0")")
 
 judges --verbose update --quiet --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"

--- a/entry.sh
+++ b/entry.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex
+set -e
 set -o pipefail
 
 id=$1
@@ -17,7 +17,17 @@ if [ -z "${home}" ]; then
   exit 1
 fi
 
-self=$(dirname "$0")
+if [ ! -d "${home}" ]; then
+  echo "Directory '${home}' does not exist"
+  exit 1
+fi
 
-judges --verbose update --quiet --summary --max-cycles=3 --no-log \
+if ! command -v judges &>/dev/null; then
+  echo "'judges' executable not found. Make sure the 'judges' gem is installed."
+  exit 1
+fi
+
+self=$(cd "$(dirname "$0")" && pwd)
+
+judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"

--- a/entry.sh
+++ b/entry.sh
@@ -29,5 +29,5 @@ fi
 
 self=$(cd "$(dirname "$0")" && pwd)
 
-judges update --summary --max-cycles=3 --no-log \
+judges --verbose update --quiet --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -19,24 +19,11 @@ class TestEntry < Minitest::Test
     Dir.mktmpdir do |dir|
       home = File.join(dir, 'home')
       FileUtils.mkdir_p(home)
-      link_dir = File.join(dir, 'linkdir')
-      FileUtils.mkdir_p(link_dir)
-      link = File.join(link_dir, 'entry.sh')
-      FileUtils.ln_s(File.expand_path('../entry.sh', __dir__), link)
-      args = File.join(dir, 'args.txt')
-      bin = judges_stub(dir)
-      stdout, stderr, status = Open3.capture3(
-        { 'PATH' => "#{bin}:#{ENV.fetch('PATH')}", 'JUDGES_ARGS_FILE' => args },
-        link, 'job-42', home
-      )
+      link = symlink_entry(dir)
+      passed = run_entry(judges_stub(dir), home, File.join(dir, 'args.txt'), script: link)
 
-      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
-      passed = File.readlines(args, chomp: true)
-      lib = passed[passed.index('--lib') + 1]
-      judges = passed[passed.index('--lib') + 2]
-
-      assert_equal(File.expand_path('../lib', __dir__), lib)
-      assert_equal(File.expand_path('../judges', __dir__), judges)
+      assert_equal(File.expand_path('../lib', __dir__), passed[passed.index('--lib') + 1])
+      assert_equal(File.expand_path('../judges', __dir__), passed[passed.index('--lib') + 2])
     end
   end
 
@@ -65,13 +52,21 @@ class TestEntry < Minitest::Test
     bin
   end
 
-  def run_entry(bin, home, args)
+  def run_entry(bin, home, args, script: './entry.sh')
     stdout, stderr, status = Open3.capture3(
       { 'PATH' => "#{bin}:#{ENV.fetch('PATH')}", 'JUDGES_ARGS_FILE' => args },
-      './entry.sh', 'job-42', home
+      script, 'job-42', home
     )
 
     assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
     File.readlines(args, chomp: true)
+  end
+
+  def symlink_entry(dir)
+    link_dir = File.join(dir, 'linkdir')
+    FileUtils.mkdir_p(link_dir)
+    link = File.join(link_dir, 'entry.sh')
+    FileUtils.ln_s(File.expand_path('../entry.sh', __dir__), link)
+    link
   end
 end

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -15,6 +15,31 @@ class TestEntry < Minitest::Test
     File.write(ENV.fetch('JUDGES_ARGS_FILE'), ARGV.join("\n"))
   RUBY
 
+  def test_resolves_real_path_when_invoked_via_symlink
+    Dir.mktmpdir do |dir|
+      home = File.join(dir, 'home')
+      FileUtils.mkdir_p(home)
+      link_dir = File.join(dir, 'linkdir')
+      FileUtils.mkdir_p(link_dir)
+      link = File.join(link_dir, 'entry.sh')
+      FileUtils.ln_s(File.expand_path('../entry.sh', __dir__), link)
+      args = File.join(dir, 'args.txt')
+      bin = judges_stub(dir)
+      stdout, stderr, status = Open3.capture3(
+        { 'PATH' => "#{bin}:#{ENV.fetch('PATH')}", 'JUDGES_ARGS_FILE' => args },
+        link, 'job-42', home
+      )
+
+      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+      passed = File.readlines(args, chomp: true)
+      lib = passed[passed.index('--lib') + 1]
+      judges = passed[passed.index('--lib') + 2]
+
+      assert_equal(File.expand_path('../lib', __dir__), lib)
+      assert_equal(File.expand_path('../judges', __dir__), judges)
+    end
+  end
+
   def test_forwards_job_id_to_judges_options
     Dir.mktmpdir do |dir|
       home = File.join(dir, 'home')

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -19,12 +19,16 @@ class TestEntry < Minitest::Test
     Dir.mktmpdir do |dir|
       home = File.join(dir, 'home')
       FileUtils.mkdir_p(home)
-      link = symlink_entry(dir)
-      passed = run_entry(judges_stub(dir), home, File.join(dir, 'args.txt'), script: link)
 
-      assert_equal(File.expand_path('../lib', __dir__), passed[passed.index('--lib') + 1])
-      assert_equal(File.expand_path('../judges', __dir__), passed[passed.index('--lib') + 2])
+      assert_real_path_used(
+        run_entry(judges_stub(dir), home, File.join(dir, 'args.txt'), script: symlink_entry(dir))
+      )
     end
+  end
+
+  def assert_real_path_used(passed)
+    assert_equal(File.expand_path('../lib', __dir__), passed[passed.index('--lib') + 1])
+    assert_equal(File.expand_path('../judges', __dir__), passed[passed.index('--lib') + 2])
   end
 
   def test_forwards_job_id_to_judges_options


### PR DESCRIPTION
entry.sh is the Docker entry point and must fail early with clear error messages when prerequisites are not met.

Changes:
- Added directory existence check for the home directory
- Added judges binary check via `command -v` with a clear error message
- Fixed `dirname \"\$0\"` to handle symlinks and relative paths (`cd \"\$(dirname \"\$0\")\" && pwd`)
- Removed `set -x` (debug tracing) from the production script

Fixes #254