### PR TITLE
#253: Exclude .git directory from bashate file search

### DIFF
--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -21,5 +21,5 @@ jobs:
           python-version: 3.14
       - run: pip install bashate
       - run: |
-          readarray -t files < <(find . -name '*.sh')
+          readarray -t files < <(find . -name '*.sh' -not -path './.git/*')
           bashate -i E006,E003 "${files[@]}"


### PR DESCRIPTION
The bashate workflow used `find . -name '*.sh'` without excluding `.git/`, which could pick up shell scripts from `.git/hooks/` and attempt to lint them.

Added `-not -path './.git/*'` to the find command.

Fixes #256