### PR TITLE
#224: remove conflicting --verbose --quiet flags in judges call

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -19,5 +19,5 @@ fi
 
 self=$(dirname "$0")
 
-judges --verbose update --quiet --summary --max-cycles=3 --no-log \
+judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"


### PR DESCRIPTION
The `entry.sh` script passes both `--verbose` and `--quiet` to the same `judges update` call, which express opposite intents. Whichever flag the option parser resolves last silently neutralises the other.

Since the shell already runs under `set -x` at that point, the verbose signal from judges is redundant with the shell trace.

Changes:
- Removed both `--verbose` and `--quiet` flags from the `judges update` call

Fixes #224