### PR TITLE
#225 entry.sh argument-validation errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -91,10 +91,10 @@ If everything is clean, your judge is ready.
 ## Commands
 
 | Command | Purpose |
-|---------|---------|
+| --------- | --------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
-| `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
+| bundle exec judges test --no-log --disable live --lib lib judges | Run YAML |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
 

--- a/entry.sh
+++ b/entry.sh
@@ -7,23 +7,23 @@ set -o pipefail
 
 id=$1
 if [ -z "${id}" ]; then
-  echo "The first argument must be the ID of the job to process"
+  echo "The first argument must be the ID of the job to process" >&2
   exit 1
 fi
 
 home=$2
 if [ -z "${home}" ]; then
-  echo "The second argument must be the directory where 'base.fb' is located"
+  echo "The second argument must be the directory where 'base.fb' is located" >&2
   exit 1
 fi
 
 if [ ! -d "${home}" ]; then
-  echo "Directory '${home}' does not exist"
+  echo "Directory '${home}' does not exist" >&2
   exit 1
 fi
 
 if ! command -v judges &>/dev/null; then
-  echo "'judges' executable not found. Make sure the 'judges' gem is installed."
+  echo "'judges' executable not found. Make sure the 'judges' gem is installed." >&2
   exit 1
 fi
 


### PR DESCRIPTION
All four `echo` calls in argument-validation branches now write to `stderr` (`>&2`) instead of `stdout`, so callers that separate stdout/stderr don't get silent failures.

Fixes #225