### PR TITLE
#228 Replace ARGV with ENV for --live/--verbose flags in Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -91,10 +91,10 @@ If everything is clean, your judge is ready.
 ## Commands
 
 | Command | Purpose |
-|---------|---------|
+| --------- | --------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
-| `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
+| bundle exec judges test --no-log --disable live --lib lib judges | Run YAML |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
 

--- a/Rakefile
+++ b/Rakefile
@@ -23,8 +23,8 @@ end
 
 desc 'Test all judges'
 task :judges do
-  live = ARGV.include?('--live') ? '' : '--disable live'
-  sh "judges #{ARGV.include?('--verbose') ? '--verbose' : ''} test --no-log #{live} --lib lib judges"
+  live = ENV['LIVE'] ? '' : '--disable live'
+  sh "judges #{ENV['VERBOSE'] ? '--verbose' : ''} test --no-log #{live} --lib lib judges"
 end
 
 require 'rubocop/rake_task'


### PR DESCRIPTION
Rake consumes CLI flags before the task body runs, so `ARGV.include?('--live')` and `ARGV.include?('--verbose')` in `Rakefile:26-27` never see those flags — Rake aborts with `invalid option: --live`.

Switch to environment variables:

- `LIVE=true bundle exec rake judges` — enables live API
- `VERBOSE=true bundle exec rake judges` — enables verbose output

Fixes #228