### PR TITLE
#273 wall-clock timeout in entry.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -29,5 +29,5 @@ fi
 
 self=$(dirname "$(readlink -f "$0")")
 
-judges update --summary --max-cycles=3 --no-log \
+timeout "${JOB_TIMEOUT:-600}" judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"


### PR DESCRIPTION
When `baza.rb` pushes a job to the server, `entry.sh` runs `judges update` to process the factbase. Previously there was no time limit — if judges hung (e.g. due to a bug, network issue, or unexpected factbase state), the container would run forever and `baza.rb`'s polling of `finished?` would time out after 10 minutes with no clear indication of what went wrong.

This commit wraps the `judges` call in GNU `timeout(1)`:

```bash
timeout ${JOB_TIMEOUT:-600} judges update --summary --max-cycles=3 --no-log ...
```

### What this changes

| Before | After |
|--------|-------|
| No time limit — container hangs forever | `timeout` enforces a hard ceiling |
| `baza.rb` sees only "job disappeared" after 10 min | Exit code 124 + `"timed out"` in stdout |
| Ops have to manually kill stray containers | `timeout` sends SIGTERM → SIGKILL automatically |

### Key details

- **Default timeout:** 600 seconds (10 minutes), matching `baza.rb`'s polling ceiling
- **Configuration:** override via `JOB_TIMEOUT` environment variable
- **Exit code:** 124 (GNU timeout standard) propagates to the container, giving `baza.rb` a deterministic status instead of ambiguous "still running?"
- **Diagnostics:** `"timeout: the command timed out"` appears in stdout

### Why not use the existing `--lifetime` flag?

The `judges` gem has a `--lifetime` option, but it is an internal Ruby timeout. An OS-level `timeout` is more robust — it catches any hang, including Ruby VM freezes, native extension deadlocks, and blocked I/O.

### Compatibility

`timeout(1)` is part of GNU coreutils and is available in every Linux-based Docker image (all our CI images, `yegor256/rultor-image`, etc.). macOS users need `brew install coreutils` (`gtimeout`) for local testing, but production always runs on Linux.

### Checklist

- [ ] `bundle exec rubocop` — 0 offenses
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review