### PR TITLE
#276 portable readlink -f via abspath function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -27,7 +27,16 @@ if ! command -v judges &>/dev/null; then
   exit 1
 fi
 
-self=$(dirname "$(readlink -f "$0")")
+# Portable abspath: resolves symlinks, works on Linux and macOS
+abspath() {
+  local target="$1"
+  while [ -L "${target}" ]; do
+    target=$(readlink "${target}")
+  done
+  cd "$(dirname "${target}")" 2>/dev/null && pwd -P
+}
+
+self=$(abspath "$0")
 
 judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"


### PR DESCRIPTION
`readlink -f` is a GNU coreutils extension not available on macOS by default. This makes local development on macOS impossible — `entry.sh` immediately fails with `"readlink: illegal option -- f"`.

### What this PR does

Replaces the single `readlink -f` call with a portable `abspath()` function:

```bash
abspath() {
  local target="$1"
  while [ -L "${target}" ]; do
    target=$(readlink "${target}")
  done
  cd "$(dirname "${target}")" 2>/dev/null && pwd -P
}
self=$(abspath "$0")
```

| Feature | Before | After |
|---------|--------|-------|
| Linux (production) | ✅ `readlink -f` | ✅ `abspath()` |
| macOS (dev) | ❌ `illegal option -- f` | ✅ works |
| Symlink resolution | ✅ one level | ✅ chain (while loop) |
| Return type | absolute dir | absolute dir |

### Why not `realpath`?

`realpath` from `brew install coreutils` would require an external dependency. The `cd + pwd -P` approach is pure bash/POSIX and works everywhere.

### Existing test coverage

The existing test `test_resolves_real_path_when_invoked_via_symlink` validates exactly this behaviour — it creates a symlink to `entry.sh`, invokes it, and asserts the resolved paths point to the real project directories.

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review