### PR TITLE
#277 make factbase filename configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -13,7 +13,7 @@ fi
 
 home=$2
 if [ -z "${home}" ]; then
-  echo "The second argument must be the directory where 'base.fb' is located"
+  echo "The second argument must be the directory with the factbase"
   exit 1
 fi
 
@@ -21,6 +21,8 @@ if [ ! -d "${home}" ]; then
   echo "Directory '${home}' does not exist"
   exit 1
 fi
+
+fb_file=${3:-${FB_FILE:-base.fb}}
 
 if ! command -v judges &>/dev/null; then
   echo "'judges' executable not found. Make sure the 'judges' gem is installed."
@@ -30,4 +32,4 @@ fi
 self=$(dirname "$(readlink -f "$0")")
 
 judges update --summary --max-cycles=3 --no-log \
-       --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"
+       --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/${fb_file}"


### PR DESCRIPTION
The factbase filename was hardcoded as `"${home}/base.fb"`. If the server or `baza.rb` ever changes the filename (e.g. `live.fb`, `snapshot.fb`), `entry.sh` silently fails with a confusing "file not found" error from `judges`.

### What this PR does

Adds a configurable factbase filename with three fallback sources (first wins):

```bash
fb_file=${3:-${FB_FILE:-base.fb}}
```

| Priority | Source | Example |
|----------|--------|---------|
| 1 (highest) | Third CLI argument | `entry.sh job-42 /home/data live.fb` |
| 2 | `FB_FILE` env var | `FB_FILE=snapshot.fb entry.sh job-42 /home/data` |
| 3 (default) | Hardcoded | `base.fb` (backwards compatible) |

### Why not just an env var?

Some orchestrators don't set env vars consistently. The CLI argument allows `baza.rb` (or any caller) to explicitly pass the filename without relying on environment propagation.

### Backwards compatibility

All existing callers (`entry.sh <id> <home>`) continue to work — the default is still `base.fb`. The existing test `test_forwards_job_id_to_judges_options` still passes because it passes no `$3` and expects the default path.

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review
