### PR TITLE
#279 print judges and fbe versions at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -27,6 +27,9 @@ if ! command -v judges &>/dev/null; then
   exit 1
 fi
 
+echo "judges: $(judges --version 2>&1)"
+echo "fbe: $(ruby -e 'puts Gem::Specification.find_by_name(%(fbe)).version' 2>/dev/null || echo 'unknown')"
+
 self=$(dirname "$(readlink -f "$0")")
 
 judges update --summary --max-cycles=3 --no-log \


### PR DESCRIPTION
When diagnosing CI or job failures it's often unclear which version of `judges` or `fbe` was used. This is especially important now that `fbe` and `judges` have broad version constraints (`~>0`).

### What this PR does

Prints both gem versions to stdout before `judges update` runs:

```
judges: 0.60.4
fbe: 0.48.5
```

`baza.rb` (or any operator reading job logs) can now see the exact versions without checking `Gemfile.lock` or the Docker image.

For `judges` — uses `judges --version` (CLI flag).
For `fbe` — uses Ruby's `Gem::Specification` since fbe has no standalone CLI.

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review
