### PR TITLE
#280 print start/finish timestamps for job progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -29,5 +29,7 @@ fi
 
 self=$(dirname "$(readlink -f "$0")")
 
+echo "Job ${id} started at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"
+echo "Job ${id} finished at $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
`baza.rb` polls `finished?` without any indication of whether the job actually started or how long it's been running. The user sees only "waiting..." until the polling timeout.

### What this PR does

Adds ISO 8601 timestamps around `judges update`:

```
Job 79196 started at 2026-06-29T20:15:30Z
... (judges output) ...
Job 79196 finished at 2026-06-29T20:16:45Z
```

### What this enables

| Scenario | Before | After |
|----------|--------|-------|
| Job starts | No signal | `"started at ..."` visible in stdout |
| Job completes | Only judges output | `"started at ..."` + `"finished at ..."` |
| Job crashes | Nothing, baza.rb hangs | `"started at ..."` only — signals abnormal exit |

If `judges update` fails (non-zero exit), `set -e` means only the start timestamp is printed — which itself signals that the job started but didn't complete normally.

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review
