### PR TITLE
#282 periodic heartbeat to prevent Docker idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 

--- a/entry.sh
+++ b/entry.sh
@@ -29,5 +29,15 @@ fi
 
 self=$(dirname "$(readlink -f "$0")")
 
+heartbeat_interval="${HEARTBEAT_INTERVAL:-60}"
+(
+  while true; do
+    sleep "${heartbeat_interval}"
+    echo "[heartbeat] Job ${id} is still running at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  done
+) &
+heartbeat_pid=$!
+trap 'kill "${heartbeat_pid}" 2>/dev/null || true' EXIT
+
 judges update --summary --max-cycles=3 --no-log \
        --option "id=${id}" --lib "${self}/lib" "${self}/judges" "${home}/base.fb"


### PR DESCRIPTION
Long-running `judges update` sessions can exceed Docker's stdout-idle timeout, causing the container to be killed silently.

### What this PR does

Emits a timestamped `[heartbeat]` line to stdout every `HEARTBEAT_INTERVAL` seconds (default 60) while judges runs:

```
[heartbeat] Job 79196 is still running at 2026-06-29T20:15:30Z
[heartbeat] Job 79196 is still running at 2026-06-29T20:16:30Z
```

A `trap` on EXIT ensures the background heartbeat process is always cleaned up — even when judges fails via `set -e`.

### Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `HEARTBEAT_INTERVAL` | `60` | Seconds between heartbeat lines |

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review