### PR TITLE
#284 fix markdownlint violations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ based on business rules. Judges run in cycles until no new facts are produced.
 
 ## Project Structure
 
-```
+```text
 judges/<name>/<name>.rb     — judge implementation, auto-discovered
 judges/<name>/<name>.yml    — YAML test for the judge (data-driven)
 lib/                        — shared Ruby libraries
@@ -41,7 +41,7 @@ bundle exec rake
 mkdir judges/hello-world
 ```
 
-2. Write the judge logic in `judges/hello-world/hello-world.rb`:
+1. Write the judge logic in `judges/hello-world/hello-world.rb`:
 
 ```ruby
 # frozen_string_literal: true
@@ -56,7 +56,7 @@ Fbe.fb.query('(and (exists hi) (absent hello))').each do |f|
 end
 ```
 
-3. Write a YAML test in `judges/hello-world/hello-world.yml`:
+1. Write a YAML test in `judges/hello-world/hello-world.yml`:
 
 ```yaml
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
@@ -74,13 +74,13 @@ expected:
   - /fb/f[_id=1]/hello
 ```
 
-4. Run the judge YAML tests:
+1. Run the judge YAML tests:
 
 ```bash
 bundle exec judges test --no-log --disable live --lib lib judges
 ```
 
-5. Run the full build:
+1. Run the full build:
 
 ```bash
 bundle exec rake
@@ -90,13 +90,15 @@ If everything is clean, your judge is ready.
 
 ## Commands
 
+<!-- markdownlint-disable MD013 -->
 | Command | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `bundle exec rake` | Full build (test + judges + rubocop) |
 | `bundle exec rake test` | Ruby unit tests only |
 | `bundle exec judges test --no-log --disable live --lib lib judges` | Judge YAML tests |
 | `bundle exec rubocop` | Code style check |
 | `docker build -t swarm .` | Build Docker image (requires Dockerfile) |
+<!-- markdownlint-enable MD013 -->
 
 ## How to Contribute
 


### PR DESCRIPTION
## Problem

Every push to `master` fails the `markdown-lint` workflow with 10 errors. CI has been red since June 13.

### Root cause

PR #246 ("Rewrite README with full documentation and quick start guide") was created on **June 8** — before the `markdown-lint` workflow had a `pull_request` trigger (that was added by PR #240 on June 13). When #240 was merged, nobody pushed to #246's branch to re-trigger CI. GitHub Actions does **not** automatically re-run checks on open PRs when a new workflow lands on the base branch.

Result: #246 was merged with 10 markdownlint violations, and they've blocked CI on every push to master since.

**Timeline (June 13):**

| Time | PR | Event |
|------|----|-------|
| 07:16 | #240 | `pull_request` trigger added to markdown-lint workflow |
| 07:30 | #246 | **Merged** — introduces 10 markdownlint errors in README.md |
| 07:44 | #235 | Merged on top — same errors, same CI failure |

### Violations fixed

| Line | Rule | Fix |
|------|------|-----|
| 18 | MD040 | Fenced code block without language → ```` ```text ```` |
| 44, 59, 77, 83 | MD029 | List prefix `2.`/`3.`/`4.`/`5.` → `1.` |
| 94 | MD060 | Table separator `|---------|---------|` → `| ------- | ------- |` |
| 97 | MD013 | Long line suppressed via `<!-- markdownlint-disable MD013 -->` wrapping the table |

### Long‑term prevention

This scenario (open PR bypasses a new CI workflow on master) could have been avoided if the branch protection rules required `markdown-lint` as a mandatory status check. Without that, any PR opened before a new workflow is added to the repo can slip through — even with the `pull_request` trigger now in place.

### Verification

```text
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: README.md
Linting: 1 file(s)
Summary: 0 error(s)
```

### Checklist

- [ ] `bundle exec rubocop` — 0 offences
- [ ] `bundle exec rake` — all tasks pass
- [ ] HoC ≤ 133

@yegor256 please review
